### PR TITLE
Cache plugin builds

### DIFF
--- a/src/Dotx64Managed/AssemblyLoader.cs
+++ b/src/Dotx64Managed/AssemblyLoader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -15,6 +15,30 @@ namespace Dotx64Dbg
         public AssemblyLoader()
             : base(true)
         {
+            /*
+             * Some plugin dependencies don't trigger the AssemblyLoadContext.Load()
+             * So we need to load any missing dependency to the app domain 'manually'
+            */
+            AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
+        }
+
+        private Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)
+        {
+            var assemblyName = new System.Reflection.AssemblyName(args.Name);
+
+            var extenalDll = externalAssemblies.FirstOrDefault(file => System.IO.Path.GetFileNameWithoutExtension(file)
+                .Equals(assemblyName.Name, StringComparison.InvariantCultureIgnoreCase));
+
+            if (extenalDll is not null)
+            {
+                externalAssemblies.Remove(extenalDll);
+                return System.Reflection.Assembly.LoadFrom(extenalDll);
+            }
+
+            // If the required assembly is not in the list it's probably because it is already loaded in the current domain.
+            // So as the last resource we gonna try to find it in the current domain;
+            var requiredAssembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(assembly => assembly.FullName == assemblyName.FullName);
+            return requiredAssembly;
         }
 
         protected override Assembly Load(AssemblyName assemblyName)
@@ -22,7 +46,16 @@ namespace Dotx64Dbg
 #if DEBUG
             Console.WriteLine("[DEBUG] LoaderContext.Load({0})", assemblyName.Name);
 #endif
-            return Assembly.Load(assemblyName);
+            var extenalDll = externalAssemblies.FirstOrDefault(file => System.IO.Path.GetFileNameWithoutExtension(file)
+                .Equals(assemblyName.Name, StringComparison.InvariantCultureIgnoreCase));
+
+            if(extenalDll is not null)
+            {
+                externalAssemblies.Remove(extenalDll);
+                return Assembly.LoadFile(extenalDll);
+            }
+
+            return Assembly.Load(assemblyName); // The assembly is already loaded in the context (We hope so)
         }
 
         public Assembly LoadFromFile(string path)
@@ -42,9 +75,29 @@ namespace Dotx64Dbg
             return true;
         }
 
+        public void AddExternalRequiredAssemblies(ICollection<string> assembliesPath)
+        {
+            var loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies();
+            foreach(string assemblyPath in assembliesPath)
+            {
+                // Filter assemblies that are already loaded
+                var assemblyName = System.Reflection.AssemblyName.GetAssemblyName(assemblyPath);
+                if (loadedAssemblies.Any(assembly => assembly.FullName == assemblyName.FullName))
+                    continue;
+                externalAssemblies.Add(assemblyPath);
+            }
+        }
+
         public bool IsLoaded()
         {
             return Current != null;
         }
+
+        ~AssemblyLoader()
+        {
+            AppDomain.CurrentDomain.AssemblyResolve -= CurrentDomain_AssemblyResolve;
+        }
+
+        private HashSet<string> externalAssemblies = new();
     }
 }

--- a/src/Dotx64Managed/Manager.cs
+++ b/src/Dotx64Managed/Manager.cs
@@ -19,7 +19,7 @@ namespace Dotx64Dbg
         {
             PluginHandle = pluginHandle;
 
-            AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
+            AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_NugetDepsAssemblyResolve;
 
             Logging.Initialize();
             Commands.Initialize();
@@ -43,7 +43,7 @@ namespace Dotx64Dbg
             PluginManager.Initialize();
         }
 
-        private static System.Reflection.Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)
+        private static System.Reflection.Assembly CurrentDomain_NugetDepsAssemblyResolve(object sender, ResolveEventArgs args)
         {
             var libs = new DirectoryInfo(Utils.DotX64DbgNugetDepsPath).GetFiles("*.dll");
             var assemblyName = new System.Reflection.AssemblyName(args.Name);

--- a/src/Dotx64Managed/Plugins.Builder.cs
+++ b/src/Dotx64Managed/Plugins.Builder.cs
@@ -159,7 +159,111 @@ namespace Dotx64Dbg
                     continue;
                 }
 
+                // We need to check if a rebuild is indeed necessary
+                var cacheFile = Path.Combine(plugin.Path, "plugin.cache");
+                if (plugin.AssemblyPath is null && File.Exists(cacheFile))
+                {
+                    if (InitializePluginFromCache(plugin, cacheFile))
+                    {
+                        ReloadPlugin(plugin, plugin.AssemblyPath, token);
+                        Utils.DebugPrintLine($"Loaded plugin '{plugin.Info.Name}' from CACHE");
+                        DeleteNotUsedPluginCache(plugin);
+                        plugin.RequiresRebuild = false;
+                        continue;
+                    }
+                    else
+                        Utils.DebugPrintLine($"Skiping cache...");
+                }
                 RebuildPlugin(plugin, token);
+                CachePluginBuild(plugin, cacheFile);
+                DeleteNotUsedPluginCache(plugin);
+            }
+
+            void DeleteNotUsedPluginCache(Plugin plugin)
+            {
+                var oldFiles = Directory.GetFiles(plugin.BuildOutputPath, "*.*", SearchOption.AllDirectories);
+                string baseFileName = Path.GetFileNameWithoutExtension(plugin.AssemblyPath);
+
+                foreach (var oldFile in oldFiles)
+                {
+                    if (Path.GetFileNameWithoutExtension(oldFile).Equals(baseFileName, StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    try
+                    {
+                        if (oldFile.EndsWith(".dll") || oldFile.EndsWith(".pdb"))
+                        {
+                            File.Delete(oldFile);
+                        }
+                    }
+                    catch (Exception)
+                    {
+                    }
+                }
+            }
+
+            uint ComputePluginSourcesHash(Plugin plugin)
+            {
+                uint hash = uint.MaxValue;
+                var md5 = System.Security.Cryptography.MD5.Create();
+                foreach (var source in plugin.SourceFiles)
+                {
+                    var md5Hash = md5.ComputeHash(File.ReadAllBytes(source));
+                    foreach (byte b in md5Hash)
+                        hash = (hash >> 8) ^ b;
+                }
+                return hash;
+            }
+
+            void CachePluginBuild(Plugin plugin, string cacheFilePath)
+            {
+                using var fs = File.OpenWrite(cacheFilePath);
+                using System.IO.Compression.ZipArchive zipArchive = new(fs, System.IO.Compression.ZipArchiveMode.Create);
+                var entry = zipArchive.CreateEntry(nameof(Plugin));
+                using BinaryWriter bw = new(entry.Open());
+                bw.Write((uint)0x4D5A); // ZM magic number ;)
+                bw.Write(ComputePluginSourcesHash(plugin)); // uint32 hash
+                bw.Write(plugin.AssemblyPath);
+                bw.Write(plugin.BuildOutputPath);
+                bw.Write((uint)0x4D5A);
+            }
+
+            bool InitializePluginFromCache(Plugin plugin, string cacheFilePath)
+            {
+                try
+                {
+                    using System.IO.Compression.ZipArchive zipArchive = System.IO.Compression.ZipFile.OpenRead(cacheFilePath);
+                    var entry = zipArchive.GetEntry(nameof(Plugin));
+                    if(entry is null)
+                        return false;
+
+                    using BinaryReader br = new(entry.Open());
+
+                    if (br.ReadUInt32() != 0x4D5A) // Check magic
+                        return false;
+
+                    uint hash = br.ReadUInt32();
+                    if (hash != ComputePluginSourcesHash(plugin)) // Modified source files
+                        return false;
+
+                    string assemblyPath = br.ReadString();
+                    if (!File.Exists(assemblyPath)) // Invalid cache
+                        return false;
+                    string buildOutputPath = br.ReadString();
+
+                    if (br.ReadUInt32() != 0x4D5A) // Check magic
+                        return false;
+
+                    plugin.AssemblyPath = assemblyPath;
+                    plugin.BuildOutputPath = buildOutputPath;
+                    return true;
+
+                } catch (Exception ex)
+                {
+                    if (ex is FormatException || ex is EndOfStreamException || ex is InvalidDataException)
+                        return false;
+                    throw;
+                }
             }
         }
     }

--- a/src/Dotx64Managed/Plugins.Builder.cs
+++ b/src/Dotx64Managed/Plugins.Builder.cs
@@ -160,7 +160,9 @@ namespace Dotx64Dbg
                 }
 
                 // We need to check if a rebuild is indeed necessary
-                var cacheFile = Path.Combine(plugin.Path, "plugin.cache");
+                var cacheDirectory = new DirectoryInfo(Path.Combine(plugin.BuildOutputPath, ".cache"));
+                cacheDirectory.Create();
+                var cacheFile = Path.Combine(cacheDirectory.FullName, "last_build");
                 if (plugin.AssemblyPath is null && File.Exists(cacheFile))
                 {
                     if (InitializePluginFromCache(plugin, cacheFile))

--- a/src/Dotx64Managed/Plugins.Hotload.cs
+++ b/src/Dotx64Managed/Plugins.Hotload.cs
@@ -457,6 +457,7 @@ namespace Dotx64Dbg
                 UnloadPluginInstance(plugin, token);
 
                 var loader = new AssemblyLoader();
+                loader.AddExternalRequiredAssemblies(plugin.ResolveDependencies(dependencyResolver, token));
                 var newAssembly = loader.LoadFromFile(newAssemblyPath);
 
                 var pluginClass = GetPluginClass(newAssembly);

--- a/src/Dotx64Managed/Plugins.cs
+++ b/src/Dotx64Managed/Plugins.cs
@@ -51,7 +51,7 @@ namespace Dotx64Dbg
         string PluginOutputPath;
 
         FileSystemWatcher PluginWatch;
-        NuGetDependencyResolver dependencyResolver;
+        DependencyResolver dependencyResolver;
 
         List<Plugin> Registered = new();
 
@@ -104,6 +104,8 @@ namespace Dotx64Dbg
             PluginWatch.Changed += OnPluginChange;
 
             dependencyResolver = new();
+            dependencyResolver.AddResolver(new NuGetDependencyResolver());
+            dependencyResolver.AddResolver(new LocalAssembliesResolver());
 
             RegisterPlugins();
             GenerateProjects();
@@ -219,22 +221,6 @@ namespace Dotx64Dbg
             if (!Directory.Exists(plugin.BuildOutputPath))
             {
                 Directory.CreateDirectory(plugin.BuildOutputPath);
-            }
-
-            // Delete the old cache.
-            var oldFiles = Directory.GetFiles(plugin.BuildOutputPath, "*.*", SearchOption.AllDirectories);
-            foreach (var oldFile in oldFiles)
-            {
-                try
-                {
-                    if (oldFile.EndsWith(".dll") || oldFile.EndsWith(".pdb"))
-                    {
-                        File.Delete(oldFile);
-                    }
-                }
-                catch (Exception)
-                {
-                }
             }
 
             Registered.Add(plugin);


### PR DESCRIPTION
Major changes:
- The `AssemblyLoader` class is now responsible for loading all required plugin dependencies to the current domain. 
This solves the issue that dependencies only got loaded in rebuild time

- A refactor in dependency management

- Support for plugin build cache