### PR TITLE
API Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ assembly references being setup. If you want to debug your plugins
 simply attach Visual Studio to x64Dbg and place the breakpoints where
 you would like to stop, its as simple as that.
 
-There is also test plugin available [here](bin/dotplugins/myplugin)
+There is also a comprehensive example plugin available [here](bin/dotplugins/example)
 
 # Scripting
 DotX64Dbg also provides a scripting interface, unlike plugins a script

--- a/bin/dotplugins/.gitignore
+++ b/bin/dotplugins/.gitignore
@@ -1,2 +1,4 @@
 .vs/
 bin/
+*.sln
+*.csproj

--- a/src/Bindings/Bindings.vcxproj
+++ b/src/Bindings/Bindings.vcxproj
@@ -77,20 +77,24 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <OutDir>$(SolutionDir)..\bin\x64\plugins\</OutDir>
     <TargetName>Dotx64Dbg.Bindings</TargetName>
+    <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutDir>$(SolutionDir)..\bin\x64\plugins\</OutDir>
     <TargetName>Dotx64Dbg.Bindings</TargetName>
+    <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <OutDir>$(SolutionDir)..\bin\x32\plugins\</OutDir>
     <TargetName>Dotx64Dbg.Bindings</TargetName>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <OutDir>$(SolutionDir)..\bin\x32\plugins\</OutDir>
     <TargetName>Dotx64Dbg.Bindings</TargetName>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <VcpkgUseStatic>true</VcpkgUseStatic>
@@ -151,6 +155,7 @@
       <AdditionalDependencies />
       <AdditionalLibraryDirectories>$(SolutionDir)include;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <DelayLoadDLLs>x32dbg.dll;x32bridge.dll;TitanEngine.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -168,6 +173,7 @@
       <DelayLoadDLLs>x64dbg.dll;x64bridge.dll;TitanEngine.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/Bindings/Instruction.Decoder.cpp
+++ b/src/Bindings/Instruction.Decoder.cpp
@@ -230,4 +230,19 @@ namespace Dotx64Dbg
     private:
 
     };
+
+    // Alias for discoverability
+    public ref class Disassembler
+    {
+    private:
+        Disassembler()
+        {
+        }
+
+    public:
+        static Decoder^ Create()
+        {
+            return Decoder::Create();
+        }
+    };
 } // namespace Dotx64Dbg

--- a/src/Bindings/Instruction.hpp
+++ b/src/Bindings/Instruction.hpp
@@ -61,7 +61,7 @@ namespace Dotx64Dbg {
 
         Instruction()
         {
-            Init(Mnemonic::Invalid);
+            Init(::Dotx64Dbg::Mnemonic::Invalid);
         }
 
     internal:
@@ -130,6 +130,14 @@ namespace Dotx64Dbg {
             }
         }
 
+        property Mnemonic Mnemonic
+        {
+            ::Dotx64Dbg::Mnemonic get()
+            {
+                return _Id;
+            }
+        }
+
         property EFlags FlagsWrite
         {
             EFlags get()
@@ -184,7 +192,7 @@ namespace Dotx64Dbg {
         {
             bool get()
             {
-                return Id == Mnemonic::Jmp;
+                return Id == ::Dotx64Dbg::Mnemonic::Jmp;
             }
         }
 

--- a/src/Bindings/Symbols.hpp
+++ b/src/Bindings/Symbols.hpp
@@ -308,7 +308,7 @@ namespace Dotx64Dbg {
             {
                 if (auto info = Detail::GetFuncInfo(address))
                 {
-                    Symbols::Function^ res = gcnew Symbols::Function(address, info->rvaStart);
+                    Symbols::Function^ res = gcnew Symbols::Function(address, (uint32_t)info->rvaStart);
                     return res;
                 }
                 return nullptr;
@@ -404,7 +404,7 @@ namespace Dotx64Dbg {
             {
                 if (auto info = Detail::GetCommentInfo(address))
                 {
-                    Symbols::Comment^ res = gcnew Symbols::Comment(address, info->rva);
+                    Symbols::Comment^ res = gcnew Symbols::Comment(address, (uint32_t)info->rva);
                     return res;
                 }
                 return nullptr;

--- a/src/Dotx64Dbg/Dotx64Dbg.vcxproj
+++ b/src/Dotx64Dbg/Dotx64Dbg.vcxproj
@@ -80,18 +80,22 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <OutDir>$(SolutionDir)..\bin\x64\plugins\</OutDir>
     <TargetExt>.dll</TargetExt>
+    <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <TargetExt>.dll</TargetExt>
     <OutDir>$(SolutionDir)..\bin\x32\plugins\</OutDir>
+    <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <TargetExt>.dll</TargetExt>
     <OutDir>$(SolutionDir)..\bin\x32\plugins\</OutDir>
+    <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TargetExt>.dll</TargetExt>
     <OutDir>$(SolutionDir)..\bin\x64\plugins\</OutDir>
+    <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnabled>false</VcpkgEnabled>

--- a/src/Dotx64DbgLoader/Dotx64DbgLoader.vcxproj
+++ b/src/Dotx64DbgLoader/Dotx64DbgLoader.vcxproj
@@ -73,10 +73,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <OutDir>$(SolutionDir)..\bin\x64\plugins\</OutDir>
     <TargetExt>.dp64</TargetExt>
+    <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <TargetExt>.dp32</TargetExt>
     <OutDir>$(SolutionDir)..\bin\x32\plugins\</OutDir>
+    <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <TargetExt>.dp32</TargetExt>
@@ -95,6 +97,7 @@
       <CompileAsManaged>false</CompileAsManaged>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <AdditionalDependencies />
@@ -110,6 +113,7 @@
       <CompileAsManaged>false</CompileAsManaged>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <AdditionalDependencies />

--- a/src/Dotx64Managed/API/Breakpoints.cs
+++ b/src/Dotx64Managed/API/Breakpoints.cs
@@ -1,4 +1,4 @@
-﻿namespace Dotx64Dbg
+namespace Dotx64Dbg
 {
     using BreakpointsNative = Native.Breakpoints;
 
@@ -7,12 +7,14 @@
         public enum Type
         {
             None = 0,
-            Normal = (1 << 0),
+            Software = (1 << 0),
             Hardware = (1 << 1),
             Memory = (1 << 2),
             Dll = (1 << 3),
             Exception = (1 << 4),
             System = (1 << 5),
+
+            Normal = Software, // Backwards compatibility
         };
 
         public enum HardwareType

--- a/src/Dotx64Managed/API/UI/UI.cs
+++ b/src/Dotx64Managed/API/UI/UI.cs
@@ -83,16 +83,22 @@ namespace Dotx64Dbg
         {
             Native.UI.Update();
         }
+
         public class UpdateSuppressor : IDisposable
         {
+            private bool wasEnabled;
+
             public UpdateSuppressor()
             {
-                UpdatesEnabled = false;
+                wasEnabled = UpdatesEnabled;
+                if(wasEnabled)
+                    UpdatesEnabled = false;
             }
 
             public void Dispose()
             {
-                UpdatesEnabled = true;
+                if(wasEnabled)
+                    UpdatesEnabled = true;
             }
         }
     }

--- a/src/asmjit/asmjit.vcxproj
+++ b/src/asmjit/asmjit.vcxproj
@@ -215,6 +215,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <TreatWarningAsError>false</TreatWarningAsError>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -246,6 +247,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <TreatWarningAsError>false</TreatWarningAsError>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/include/pluginsdk/_scriptapi_misc.h
+++ b/src/include/pluginsdk/_scriptapi_misc.h
@@ -12,7 +12,7 @@ namespace Script
         ///
         /// Expressions can consist of memory locations, registers, flags, API names, labels, symbols, variables etc.
         ///
-        /// Example: bool success = ParseExpression("[esp+8]", &val)
+        /// Example: bool success = ParseExpression("[esp+8]", &amp;val)
         /// </summary>
         /// <param name="expression">The expression to evaluate.</param>
         /// <param name="value">The result of the expression.</param>

--- a/src/zycore/zycore.vcxproj
+++ b/src/zycore/zycore.vcxproj
@@ -112,6 +112,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <TreatWarningAsError>false</TreatWarningAsError>
       <AdditionalIncludeDirectories>include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -145,6 +146,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <TreatWarningAsError>false</TreatWarningAsError>
       <AdditionalIncludeDirectories>include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/zydis/zydis.vcxproj
+++ b/src/zydis/zydis.vcxproj
@@ -118,6 +118,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <TreatWarningAsError>false</TreatWarningAsError>
       <AdditionalIncludeDirectories>include;src;$(SolutionDir)zycore\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -151,6 +152,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <TreatWarningAsError>false</TreatWarningAsError>
       <AdditionalIncludeDirectories>include;src;$(SolutionDir)zycore\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
- Moved encoder/decoder related stuff to the `Dotx64Dbg.Disassembly` namespace (name might not be ideal, but I think it's reasonably discoverable)
- Added some aliases to improve discoverability