### PR TITLE
Fix #87: Avoid loading already loaded assemblies again

### DIFF
--- a/src/Dotx64Managed/AssemblyLoader.cs
+++ b/src/Dotx64Managed/AssemblyLoader.cs
@@ -24,6 +24,8 @@ namespace Dotx64Dbg
         {
             var assemblyName = new System.Reflection.AssemblyName(args.Name);
 
+            Utils.DebugPrintLine("[DEBUG] LoaderContext.AssemblyResolve({0})", assemblyName.Name);
+
             var extenalDll = externalAssemblies.FirstOrDefault(file => System.IO.Path.GetFileNameWithoutExtension(file)
                 .Equals(assemblyName.Name, StringComparison.InvariantCultureIgnoreCase));
 
@@ -41,9 +43,16 @@ namespace Dotx64Dbg
 
         protected override Assembly Load(AssemblyName assemblyName)
         {
-#if DEBUG
-            Console.WriteLine("[DEBUG] LoaderContext.Load({0})", assemblyName.Name);
-#endif
+            Utils.DebugPrintLine("[DEBUG] LoaderContext.Load({0})", assemblyName.Name);
+
+            // See if the assembly is already loaded including the version.
+            var loadedAssembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(assembly =>
+                assembly.GetName().Name.Equals(assemblyName.Name, StringComparison.InvariantCultureIgnoreCase) &&
+                assembly.GetName().Version == assemblyName.Version);
+
+            if (loadedAssembly is not null)
+                return loadedAssembly;
+
             var extenalDll = externalAssemblies.FirstOrDefault(file => System.IO.Path.GetFileNameWithoutExtension(file)
                 .Equals(assemblyName.Name, StringComparison.InvariantCultureIgnoreCase));
 


### PR DESCRIPTION
This seems to do the trick, this was generally a bit flawed as it would load assemblies multiple times for when sub dependencies have the same assembly references, now it checks for name and version in the current domain instead of loading another one.

Closes #87